### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/termpdf.py
+++ b/termpdf.py
@@ -1851,7 +1851,7 @@ def main(args=sys.argv):
     # set up thread to watch for file changes
     file_change = threading.Event()
     file_watch = threading.Thread(target=watch_for_file_change, args=(file_change, doc.filename))
-    file_watch.setDaemon(True)
+    file_watch.daemon = True
     file_watch.start()
 
     doc_viewer = threading.Thread(target=view, args=(file_change, doc))


### PR DESCRIPTION
The setDaemon attribute has been deprecated in python 3.10

Due to this people using the latest python versions will get an annoying deprecation warning error.

And yes I did copy the PR title from https://github.com/gitpython-developers/GitPython/pull/1214 lol
