### PR TITLE
Do not hardcode ~/.config & ~/.cache

### DIFF
--- a/termpdf.py
+++ b/termpdf.py
@@ -108,7 +108,7 @@ class Config:
                     break
     
     def load_config_file(self):
-        config_file = os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), 'termpdf.py', 'config')
+        config_file = os.path.expanduser(os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), 'termpdf.py', 'config'))
         if os.path.exists(config_file):
             with open(config_file, 'r') as f:
                 prefs = json.load(f)
@@ -256,7 +256,7 @@ def get_filehash(path):
 
 def get_cachefile(path):
     filehash = get_filehash(path)
-    cachedir = os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), '.cache', 'termpdf.py')
+    cachedir = os.path.expanduser(os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), 'termpdf.py'))
     os.makedirs(cachedir, exist_ok=True)
     cachefile = os.path.join(cachedir, filehash)
     return cachefile

--- a/termpdf.py
+++ b/termpdf.py
@@ -81,8 +81,8 @@ from tempfile import NamedTemporaryFile
 class Config:
     def __init__(self):
         self.BIBTEX = ''
-        self.KITTYCMD = 'kitty --single-instance --instance-group=1' # open notes in a new OS window
-        # self.KITTYCMD = 'kitty @ new-window' # open notes in split kitty window
+        #self.KITTYCMD = 'kitty --single-instance --instance-group=1' # open notes in a new OS window
+        self.KITTYCMD = 'kitty @ new-window' # open notes in split kitty window
         self.TINT_COLOR = 'antiquewhite2'
         self.URL_BROWSER_LIST = [
             'gnome-open',
@@ -108,7 +108,7 @@ class Config:
                     break
     
     def load_config_file(self):
-        config_file = os.path.join(os.getenv('HOME'), '.config', 'termpdf.py', 'config')
+        config_file = os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), 'termpdf.py', 'config')
         if os.path.exists(config_file):
             with open(config_file, 'r') as f:
                 prefs = json.load(f)
@@ -256,7 +256,7 @@ def get_filehash(path):
 
 def get_cachefile(path):
     filehash = get_filehash(path)
-    cachedir = os.path.join(os.getenv("HOME"), '.cache', 'termpdf.py')
+    cachedir = os.path.join(os.getenv("XDG_CONFIG_HOME", "~/.config"), '.cache', 'termpdf.py')
     os.makedirs(cachedir, exist_ok=True)
     cachefile = os.path.join(cachedir, filehash)
     return cachefile


### PR DESCRIPTION
This patch makes termpdf.py respect XDG_BASE_DIR

By default termpdf saved the files to the hardcoded .config and .cache directory

Fixes #16

