### PR TITLE
Change deprecated method "invertIRect" in PyMuPDF 1.19+ Pixmap class 

### DIFF
--- a/termpdf.py
+++ b/termpdf.py
@@ -659,7 +659,7 @@ class Document(fitz.Document):
             pix = page.get_pixmap(matrix = mat, alpha=self.alpha)
 
             if self.invert:
-                pix.invertIRect()
+                pix.invert_irect()
 
             if self.tint:
                 tint = fitz.utils.getColor(self.tint_color)


### PR DESCRIPTION
In PyMuPDF versions after 1.19, Pixmap will no longer have the method "invertIRect" available. 

This warning is visible whenever inverting a pdf's colorscheme with termpdf.py. This changes the method to invert_irect and fixes the issue.