### PR TITLE
Fix: crash from reverse buffer cycling

### DIFF
--- a/termpdf.py
+++ b/termpdf.py
@@ -129,11 +129,7 @@ class Buffers:
         self.current = n
 
     def cycle(self, count):
-        l = len(self.docs) - 1
-        c = self.current + count 
-        if c > l:
-            c = 0
-        self.current = c
+        self.current = (self.current + count) % len(self.docs)
 
     def close_buffer(self,n):
         del self.docs[n]


### PR DESCRIPTION
Forward buffer cycling with bb would 'wrap around' to 0 once it reached
the final document, but cycling backwards from the first document with B
would continue into negative numbers and eventually crash once the
buffer index got low enough.  Wrap buffer cycling in both directions
with modulo.