### PR TITLE
fix setup.py keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,9 @@ Note the alpha transparency. You can toggle this on or off by pressing `a`.
 
 # Installation
 
-    git clone https://github.com/dsanson/termpdf.py
-    cd termpdf.py
-    pip install -r requirements.txt
+    python3 -m pip install git+https://github.com/dsanson/termpdf.py
 
-(You might need to use `pip3` if `pip` is Python 2 on your system.)
-
-Now you can run the script in place:
-
-    ./termpdf.py <file.pdf>
-
-Or copy it somewhere in your path.
-
-Or you can install it with pip:
-
-    pip install .
+This adds the `termpdf.py` command to your path.
 
 # Simple Usage
 

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ setup(name='termpdf.py',
       author_email='dsanson@gmail.com',
       url='https://github.com/dsanson/termpdf.py',
       scripts=['termpdf.py'],
-      requires=[
-          'PyMuPDF', 
-          'pyperclip', 
-          'pdfrw', 
-          'pybtex', 
-          'pynvim', 
+      install_requires=[
+          'PyMuPDF',
+          'pyperclip',
+          'pdfrw',
+          'pybtex',
+          'pynvim',
           'roman',
           'pagelabels'
           ]


### PR DESCRIPTION
I ran into [this issue](https://github.com/dsanson/termpdf.py/issues/17) trying to `pip install` this package.  The issue is not that `fitz` isn't listed, but the keyword for `requires` should actually be `install_requires`.  Without this keyword, `pip` actually won't install transitive dependencies.

Since the original installation instructions recommended a `git clone` followed by pip install, I modified the README to demonstrate a faster installation that combines both steps, assuming the `install_requires` keyword is in place.  Also, as [already mentioned by another user](https://github.com/dsanson/termpdf.py/issues/3#issuecomment-536316238), having a `requirements.txt` that doesn't pin versions is duplicitous of the `install_requires`, but I'll leave that to you to remove if you want.  

Furthermore, this seems like a good package to go up on PyPI, so that users can simply `pip install termpdf.py`.  If there's interest for that, I'd be happy to contribute a separate PR that would move the repo to `setuptools` or `poetry` that would simplify the build/distribution process a lot.

To see an example of the installation I wrote in the `README.md`, you could try it from my branch:
```
pip install git+https://github.com/renzmann/termpdf.py
```
