### PR TITLE
.gitignore build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+*.egg-info/


### PR DESCRIPTION
`pip install` leaves two directories in the source directory after the install. Ignore those by putting them into `.gitignore`.