### PR TITLE
fix wezterm hang by not waiting on cmd response

### DIFF
--- a/termpdf.py
+++ b/termpdf.py
@@ -681,7 +681,7 @@ class Document(fitz.Document):
             self.clear_page(self.prevpage)
             # display the image
             cmd = {'a': 'p', 'i': p + 1, 'z': -1}
-            success = write_gr_cmd_with_response(cmd)
+            success = write_gr_cmd(cmd)
             if not success:
                 self.page_states[p].stale = True
                 bar.message = 'failed to load page ' + str(p+1)


### PR DESCRIPTION
wezterm does not send a response to the image display command, so the termpdf.py read command hangs indefinitely, making it unresponsive.

this fix replaces the call to write_gr_cmd_with_response by a call to write_gr_cmd, which does not wait for a response.